### PR TITLE
Replace underscores by hyphens of branch names

### DIFF
--- a/pkg/usecases/featureorfixversion.go
+++ b/pkg/usecases/featureorfixversion.go
@@ -2,6 +2,7 @@ package usecases
 
 import (
 	"fmt"
+	"strings"
 	"github.com/Masterminds/semver"
 	"github.com/twendt/release-flow-version/pkg/repository"
 )
@@ -38,5 +39,6 @@ func FeatureOrFixBranchVersion(r *repository.GitRepo, currentBranch *repository.
 }
 
 func prereleaseStr(tag string, counter int) string {
+	tag = strings.Replace(tag, "_", "-", -1)
 	return fmt.Sprintf("%s.%d", tag, counter)
 }


### PR DESCRIPTION
Branch names may not contain underscores to use SetPrerelease of Semver.